### PR TITLE
Troubleshoot module resolution error

### DIFF
--- a/android/app/src/main/java/com/sdedola/tcalcmobile/MainApplication.kt
+++ b/android/app/src/main/java/com/sdedola/tcalcmobile/MainApplication.kt
@@ -28,7 +28,7 @@ class MainApplication : Application(), ReactApplication {
             return packages
           }
 
-          override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
+          override fun getJSMainModuleName(): String = "index"
 
           override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
 

--- a/ios/HarmonyTi/AppDelegate.mm
+++ b/ios/HarmonyTi/AppDelegate.mm
@@ -24,7 +24,8 @@
 - (NSURL *)bundleURL
 {
 #if DEBUG
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@".expo/.virtual-metro-entry"];
+  // Use the standard React Native entry file for Metro while developing.
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif


### PR DESCRIPTION
The "Unable to resolve module ./.expo/.virtual-metro-entry" error occurred because the native entry points were configured for an Expo managed project, not a bare React Native setup.

To resolve this, the Metro bundler's entry file was reconfigured:

*   In `ios/HarmonyTi/AppDelegate.mm`, the `jsBundleURLForBundleRoot:` method, used in DEBUG builds, was updated to reference `"index"` instead of `".expo/.virtual-metro-entry"`. This directs Metro to the standard React Native entry file.
*   In `android/app/src/main/java/com/sdedola/tcalcmobile/MainApplication.kt`, the `getJSMainModuleName()` method was changed to return `"index"`.

These changes ensure that both iOS and Android native modules correctly point Metro to the `index.ts` (or `index.js`) file as the application's entry point, resolving the module resolution error.