### PR TITLE
Fix serialization error in Xcode archive

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,5 @@
-// Updated Metro configuration to use @react-native/metro-config per RN ≥0.73 guidance
-const { getDefaultConfig } = require('@react-native/metro-config');
+// Metro configuration extending expo/metro-config (required for Expo-managed workflow)
+const { getDefaultConfig } = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 


### PR DESCRIPTION
The Xcode archive failed due to a "Serializer did not return expected format" error, indicating Metro's output was not in the expected JSON format.

The issue stemmed from `metro.config.js` extending `@react-native/metro-config`, which produces a plain JavaScript string. Expo's native build scripts, however, expect a `{ code, map }` JSON object from the serializer.

The fix involved:
*   Modifying `metro.config.js` to extend `expo/metro-config` instead of `@react-native/metro-config`. This ensures the correct serializer is used, providing the expected JSON output for Expo-managed/bare applications.
*   Existing configurations, such as `resolver.unstable_enablePackageExports = false` and any middleware patches, were preserved.

This change allows the Metro serializer to return the format expected by Expo tooling, resolving the JSON parsing error during the Xcode archive process.