### PR TITLE
Review Section 232 tariffs in code

### DIFF
--- a/src/services/tariffService.ts
+++ b/src/services/tariffService.ts
@@ -893,7 +893,7 @@ export class TariffService {
             // By rule_name text
             dutyRuleNameLower.includes("fentanyl") ||
             dutyRuleNameLower.includes("reciprocal tariff") ||
-            dutyRuleNameLower.includes("ieepa")
+            duty.type === "ieepa_tariff"
           ) {
             continue; // duplicate – handled later in reciprocal_tariffs pass
           }


### PR DESCRIPTION
Correctly apply Section 232 Steel tariffs by refining the IEEPA duplicate filter.

Previously, Section 232 Steel additive duties were inadvertently skipped because their `rule_name` contained "ieepa", triggering a broad duplicate filter intended for IEEPA tariffs. This change tightens the filter to only skip duties explicitly typed as `ieepa_tariff`, ensuring Section 232 duties are correctly applied without unintended side effects or double-counting.